### PR TITLE
added support to option 'transaction_timeout' option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-.installed.cfg
-bin/
-develop-eggs/
-include/
-lib/
-parts/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,13 @@ Changelog
 - Nothing changed yet.
 
 
+1.2.2.1 (2012-03-30)
+------------------
+
+- Added option 'transaction-timeout'(Maximum time amount to wait for a transaction to commit) .
+  [baijum]
+
+
 1.2.2 (2011-11-24)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 from setuptools import setup, find_packages
 
-version = '1.2.3dev'
+version = '1.2.2.1'
 
 additional_install_requires = []
 

--- a/src/plone/recipe/zeoserver/__init__.py
+++ b/src/plone/recipe/zeoserver/__init__.py
@@ -154,6 +154,9 @@ class Recipe:
             invalidation_queue_size = options.get('invalidation-queue-size',
                                                   '100')
 
+            transaction_timeout = options.get('transaction-timeout',
+                                                  '300')
+
             socket_name = options.get('socket-name',
                                       '%s/zeo.zdsock' % var_dir)
             socket_dir = os.path.dirname(socket_name)
@@ -225,6 +228,7 @@ class Recipe:
                 instance_home = instance_home,
                 effective_user = effective_user,
                 invalidation_queue_size = invalidation_queue_size,
+                transaction_timeout = transaction_timeout,
                 socket_name = socket_name,
                 z_log = z_log,
                 z_log_filename = z_log_filename,
@@ -495,6 +499,7 @@ zeo_conf_template = """\
   address %(zeo_address)s
   read-only false
   invalidation-queue-size %(invalidation_queue_size)s
+  transaction-timeout %(transaction_timeout)s
   pid-filename %(pid_file)s
   %(authentication)s
   %(monitor_address)s


### PR DESCRIPTION
Hi,
    I added an option 'transaction-timeout' in zeoserver recipe to support it.
Transaction timeout is the maximum amount of time to wait for a transaction to commit after acquiring the storage lock, specified in seconds. If the transaction takes too long, the client connection will be closed and the transaction aborted.

Suggest you to add this option in recipe.

Thanks,
Rohit Kumar
