### PR TITLE
Fix zeopack connection handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,11 @@ Changelog
   ``zeopack-script-name`` option to change the script name.
   [davidjb]
 
+- Fix zeopack connection handling. The previous fix to abort after a failed
+  connection attempt only worked by chance and caused zeopack to exit before
+  the packing finished. Now failed connections are correctly detected and
+  zeopack waits until the packing is finished.
+  [gaudenz]
 
 1.2.2 (2011-11-24)
 ------------------


### PR DESCRIPTION
The previous fix to abort after a failed connection attempt only worked
by chance and caused zeopack to exit before the packing finished. Now failed
connections are correctly detected and zeopack waits until the packing is
finished.

@mauritsvanrees could you please review and possibly merge this. Please check that the change of not waiting for the packing to be completed was really introduced accidentally. You introduced this "bug" in  130584246cadd7d7d9eaf04f20aea9ca6563f25f.
