### PR TITLE
Add default storage number in zeopack script

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add default storage number in zeopack script
+  [mamico]
 
 
 1.2.7 (2015-01-05)

--- a/src/plone/recipe/zeoserver/__init__.py
+++ b/src/plone/recipe/zeoserver/__init__.py
@@ -351,6 +351,7 @@ class Recipe:
                 realm = options.get('authentication-realm', 'ZEO')
             else:
                 realm = None
+            storage = options.get('storage-number', '1')
 
             arg_list = [
                 'host', 'port', 'unix', 'days',
@@ -365,6 +366,7 @@ class Recipe:
                 username=username,
                 password=password,
                 realm=realm,
+                storage=storage,
                 blob_dir=options.get('blob-storage', None),
             )
             arguments_info = ''
@@ -378,7 +380,7 @@ class Recipe:
                                "getopt.getopt(sys.argv[1:], 'S:B:D:W1')[0];\n"
                                "opts = dict(opts)\n"
                                "storage = opts.has_key('-S') and "
-                               "opts['-S'] or '1'\n"
+                               "opts['-S'] or storage\n"
                                "blob_dir = opts.has_key('-B') and "
                                "opts['-B'] or blob_dir\n"
                                "days = opts.has_key('-D') and "

--- a/src/plone/recipe/zeoserver/tests/zeoserver.txt
+++ b/src/plone/recipe/zeoserver/tests/zeoserver.txt
@@ -309,6 +309,33 @@ Now check the values for `host`, `port` and `unix`::
     >>> 'unix = None' in zeopack
     True
 
+When storage-number is provided, the script will assume as default::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = zeo
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [zeo]
+    ... recipe = plone.recipe.zeoserver
+    ... storage-number = 9
+    ...
+    ... ''' % globals())
+    >>> print system(join('bin', 'buildout')),
+    ...
+    Uninstalling zeo.
+    Installing zeo...
+
+Now check the values for `storage`::
+
+    >>> zeopack_path = os.path.join(sample_buildout, 'bin', 'zeopack')
+    >>> if WINDOWS:
+    ...     zeopack_path += '-script.py'
+    >>> zeopack = open(zeopack_path, 'r').read()
+    >>> 'storage = "9"' in zeopack
+    True
+
 If the `zeo-address`-parameter is a string it is assumed to be the path
 to a Unix socket file::
 


### PR DESCRIPTION
If storage-number is defined in the recipe I think that must be assumed as default for the zeopack script.