### PR TITLE
Obsoleted link for bug and questions?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,5 +236,5 @@ zeopack
 Reporting bugs or asking questions
 ----------------------------------
 
-We have a shared bugtracker and help desk on Launchpad:
-https://bugs.launchpad.net/collective.buildout/
+We have a bugtracker and help desk on Github:
+https://github.com/plone.recipe.zeoserver/issues


### PR DESCRIPTION
The link in the README to bugs and questions is currently https://launchpad.net/~collective.buildout. It is really active or obsoleted?