### PR TITLE
Add support for log rotation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add support for log rotation.
+  [hvelarde]
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,15 @@ Logging
 zeo-log
   The filename of the ZEO log file. Defaults to ``var/log/${partname}.log``.
 
+zeo-log-level
+  Control the logging level in the eventlog. Defaults to ``info``.
+
+zeo-log-max-size
+  Maximum size of ZEO log file. Enables log rotation.
+
+zeo-log-old-files
+  Number of previous log files to retain when log rotation is enabled. Defaults to ``1``.
+
 zeo-log-format
   Format of logfile entries. Defaults to ``%(asctime)s %(message)s``.
 
@@ -71,9 +80,6 @@ zeo-log-custom
   A custom section for the eventlog, to be able to use another
   event logger than ``logfile``. ``zeo-log`` is still used to set the logfile
   value in the runner section.
-
-zeo-log-level
-  Control the logging level in the eventlog. Defaults to ``info``.
 
 Authentication
 --------------

--- a/src/plone/recipe/zeoserver/__init__.py
+++ b/src/plone/recipe/zeoserver/__init__.py
@@ -183,8 +183,17 @@ class Recipe:
             # zeo-log-custom superseeds zeo-log
             logformat=options.get('zeo-log-format', '%(asctime)s %(message)s')
             if zeo_log_custom is None:
+                zeo_log_rotate = ''
+                zeo_log_max_size = options.get('zeo-log-max-size', None)
+                if zeo_log_max_size:
+                    zeo_log_old_files = options.get('zeo-log-old-files', 1)
+                    zeo_log_rotate = '\n'.join((
+                        "max-size %s" % zeo_log_max_size,
+                        "      old-files %s" % zeo_log_old_files))
                 z_log = z_log_file % {
-                    'filename': z_log_filename, 'logformat': logformat}
+                    'filename': z_log_filename,
+                    'logformat': logformat,
+                    'zeo_log_rotate': zeo_log_rotate}
             else:
                 z_log = zeo_log_custom
 
@@ -529,9 +538,10 @@ zrs_template = """
 
 
 z_log_file = """\
-     <logfile>
+    <logfile>
       path %(filename)s
       format %(logformat)s
+      %(zeo_log_rotate)s
     </logfile>
 """.strip()
 

--- a/src/plone/recipe/zeoserver/tests/zeoserver.txt
+++ b/src/plone/recipe/zeoserver/tests/zeoserver.txt
@@ -237,6 +237,48 @@ We should have a zeo.conf with a log level set to `error`::
     ...
     <BLANKLINE>
 
+ZEO log rotation
+================
+
+Using `zeo-log-max-size` option enables log rotation::
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... parts = zeo
+    ... find-links = %(sample_buildout)s/eggs
+    ...
+    ... [zeo]
+    ... recipe = plone.recipe.zeoserver
+    ... zeo-log-max-size = 10MB
+    ... zeo-log-old-files = 7
+    ...
+    ... ''' % globals())
+
+Let's run it::
+
+    >>> print system(join('bin', 'buildout')),
+    ...
+    Uninstalling zeo.
+    Installing zeo...
+
+We should have a zeo.conf with log file rotation enabled::
+
+    >>> zeo = os.path.join(sample_buildout, 'parts', 'zeo')
+    >>> print open(os.path.join(zeo, 'etc', 'zeo.conf')).read()
+    %define INSTANCE ...
+    ...
+    <eventlog>
+      level info
+      <logfile>
+        path .../sample-buildout/var/log/zeo.log
+        format %(asctime)s %(message)s
+        max-size 10MB
+        old-files 7
+      </logfile>
+    </eventlog>
+    ...
+
 Custom Zeopack
 ==============
 


### PR DESCRIPTION
This is based on the same feature found in [plone.recipe.zope2instance](https://github.com/plone/plone.recipe.zope2instance).

closes #17 