### PR TITLE
Fixed Travis tests by installing the `hyperlink` package.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed Travis tests by installing the ``hyperlink`` package.  [maurits]
 
 
 1.4.0 (2017-06-16)

--- a/src/plone/recipe/zeoserver/tests/test_docs.py
+++ b/src/plone/recipe/zeoserver/tests/test_docs.py
@@ -26,6 +26,7 @@ def setUp(test):
     install('constantly', test)
     install('attrs', test)
     install('Twisted', test)
+    install('hyperlink', test)
     dependencies = pkg_resources.working_set.require('ZODB3')
     for dep in dependencies:
         try:

--- a/src/plone/recipe/zeoserver/tests/zeoserver.txt
+++ b/src/plone/recipe/zeoserver/tests/zeoserver.txt
@@ -614,4 +614,3 @@ The main script should have the initialization.
 
     >>> 'foo = 1' in open(join('bin', 'zeo' + suffix)).read()
     True
-


### PR DESCRIPTION
See failure at https://travis-ci.org/plone/plone.recipe.zeoserver/builds/317841569 for PR #25.

Note: this package is not tested on Jenkins (I don't see it end up in `bin/test`) so we do not need to run them.