### PR TITLE
fix(gha): bump macos runner version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ["windows", "windows-latest"]
-        - ["macos", "macos-11"]
+          - ["windows", "windows-latest"]
+          - ["macos", "macos-12"]
         config:
-        # [Python version, tox env]
-        - ["3.9",   "test"]
+          # [Python version, tox env]
+          - ["3.9",   "test"]
 
     runs-on: ${{ matrix.os[1] }}
     name: ${{ matrix.os[0] }}-${{ matrix.config[1] }}

--- a/news/+ignore.tests
+++ b/news/+ignore.tests
@@ -1,0 +1,1 @@
+Bump `macos` GHA runner version, `11` has been deprecated [@gforcada]


### PR DESCRIPTION
Seems that `macos-11` has been deprecated since [June 28th 2024](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)

Is there a reason that `macos-latest` is not being used? 🤔 