### PR TITLE
Drop pkg_resources usage in tests.

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -50,5 +50,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
+    - name: Initialize tox
+      # the bash one-liner below does not work on Windows
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
     - name: Test
       run: tox -e ${{ matrix.config[2] }}

--- a/news/4126.tests.rst
+++ b/news/4126.tests.rst
@@ -1,0 +1,1 @@
+Drop ``pkg_resources`` usage.  [maurits]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2,<=75.8.0", "wheel"]
+requires = ["setuptools>=68.2,<80", "wheel"]
 
 [tool.towncrier]
 directory = "news/"
@@ -37,7 +37,7 @@ showcontent = true
 
 [[tool.towncrier.type]]
 directory = "tests"
-name = "Tests"
+name = "Tests:"
 showcontent = true
 
 ##

--- a/src/plone/recipe/zeoserver/tests/test_docs.py
+++ b/src/plone/recipe/zeoserver/tests/test_docs.py
@@ -4,7 +4,6 @@ from zc.buildout.testing import install
 from zc.buildout.testing import install_develop
 
 import doctest
-import pkg_resources
 import shutil
 import unittest
 
@@ -23,14 +22,6 @@ def setUp(test):
     install("Twisted", test)
     install("hyperlink", test)
     install("idna", test)
-    dependencies = pkg_resources.working_set.require("ZODB")
-    for dep in dependencies:
-        try:
-            install(dep.project_name, test)
-        except OSError:
-            # Some distributions are installed multiple times, and the
-            # underlying API doesn't check for it
-            pass
 
 
 def tearDown(test):

--- a/tox.ini
+++ b/tox.ini
@@ -162,6 +162,7 @@ set_env = {[base]set_env}
 deps =
     {[test_runner]deps}
     -c https://dist.plone.org/release/6.2-dev/constraints.txt
+
 commands = {[test_runner]test}
 extras = {[base]extras}
 
@@ -187,6 +188,7 @@ deps =
     {[test_runner]deps}
     coverage
     -c https://dist.plone.org/release/6.2-dev/constraints.txt
+
 commands = {[test_runner]coverage}
 extras = {[base]extras}
 


### PR DESCRIPTION
We used this to install ZODB and dependencies, but the tests keep passing when I remove these lines. This could be a left-over from a time when `ZODB` was not a dependency of us.

